### PR TITLE
Ensure that JS execution is cancelled first in order to avoid client-…

### DIFF
--- a/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
+++ b/vaadin-context-menu-flow/src/main/java/com/vaadin/flow/component/contextmenu/ContextMenuBase.java
@@ -103,14 +103,14 @@ public abstract class ContextMenuBase<C extends ContextMenuBase<C, I, S>, I exte
      */
     public void setTarget(Component target) {
         if (getTarget() != null) {
-            targetBeforeOpenRegistration.remove();
-            targetAttachRegistration.remove();
-            getTarget().getElement()
-                    .callJsFunction("$contextMenuConnector.removeConnector");
             if (isTargetJsPending()) {
                 targetJsRegistration.cancelExecution();
                 targetJsRegistration = null;
             }
+            targetBeforeOpenRegistration.remove();
+            targetAttachRegistration.remove();
+            getTarget().getElement()
+                    .callJsFunction("$contextMenuConnector.removeConnector");
         }
 
         this.target = target;


### PR DESCRIPTION
…side error

Fixes https://github.com/vaadin/vaadin-context-menu-flow/issues/104

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-context-menu-flow/115)
<!-- Reviewable:end -->
